### PR TITLE
add state struct for native invoke

### DIFF
--- a/boa/builtins.py
+++ b/boa/builtins.py
@@ -1,5 +1,15 @@
 
 
+class state():
+    """
+    this is the parameter struct for ontology native invoke parameter
+    """
+    def __init__(self,fromaddr,toaddr,amount):
+        pass
+    pass
+
+
+
 class list(list):
 
     """

--- a/boa/code/vmtoken.py
+++ b/boa/code/vmtoken.py
@@ -361,6 +361,22 @@ class VMTokenizer(object):
         self.insert1(VMOp.ROLL)
         self.insert1(VMOp.SETITEM)
 
+    def convert_state(self, pytoken):
+        """
+        convert state for ontology native transfer parameters
+        :param pytoken:
+        :return:
+        """
+        self.insert_push_integer(3)
+        self.convert1(VMOp.NEWSTRUCT)
+        self.convert1(VMOp.TOALTSTACK)
+
+        arglen = len(self.method.args)
+        while arglen > 0:
+            arglen -= 1
+            self.convert_load_parameter(self.method.args[arglen], arglen)
+        self.convert1(VMOp.FROMALTSTACK)
+
     def convert_built_in_list(self, pytoken):
         """
 
@@ -413,7 +429,8 @@ class VMTokenizer(object):
             return self.convert_push_data(bytes(pytoken.instruction.arg), pytoken)
         elif pytoken.func_name == 'bytes':
             return self.convert_push_data(pytoken.func_params[0].args, pytoken)
-
+        elif pytoken.func_name == 'state':
+            return self.convert_state(pytoken)
 #        for t in pytoken.func_params:
 #            t.to_vm(self)
 
@@ -645,7 +662,7 @@ class VMTokenizer(object):
                   'iter', 'isinstance', 'issubclass', 'input', 'id', 'hex',
                   'help', 'hash', 'hasattr', 'globals', 'format', 'exit',
                   'exec', 'eval', 'dir', 'deleteattr', 'credits', 'copyright',
-                  'compile', 'chr', 'callable', 'bin', 'ascii', 'any', 'all', ]:
+                  'compile', 'chr', 'callable', 'bin', 'ascii', 'any', 'all', 'state']:
             return True
 
         return False

--- a/boa_test/example/testStruct.py
+++ b/boa_test/example/testStruct.py
@@ -1,0 +1,45 @@
+
+from boa.interop.System.Runtime import *
+from boa.interop.Ontology.Native import *
+from boa.builtins import state
+
+contractAddress = bytearray(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
+
+
+def Main(operation, args):
+    if operation == 'transfer':
+        fromacct = args[0]
+        toacct = args[1]
+        amount = args[2]
+        return transferONT(fromacct,toacct,amount)
+
+
+    return False
+
+
+def transferONT(fromacct,toacct,amount):
+    """
+    transfer ONT
+    :param fromacct:
+    :param toacct:
+    :param amount:
+    :return:
+    """
+    if CheckWitness(fromacct):
+
+        param = state(fromacct, toacct, amount)
+        res = Invoke(1, contractAddress, 'transfer', [param])
+        Notify(res)
+
+        if res and res == b'\x01':
+            Notify('transfer succeed')
+            return True
+        else:
+            Notify('transfer failed')
+
+            return False
+
+    else:
+        Notify('checkWitness failed')
+        return False
+


### PR DESCRIPTION
add state struct for native invoke,but currently create 'state' must be within a sub function and parameters must be (fromaddress,toaddress,amount)
for example:

def transferONT(fromacct,toacct,amount):
    """
    transfer ONT
    :param fromacct:
    :param toacct:
    :param amount:
    :return:
    """
    if CheckWitness(fromacct):

        param = state(fromacct, toacct, amount)
        res = Invoke(1, contractAddress, 'transfer', [param])
        Notify(res)

        if res and res == b'\x01':
            Notify('transfer succeed')
            return True
        else:
            Notify('transfer failed')

            return False

    else:
        Notify('checkWitness failed')
        return False

we will improve this later